### PR TITLE
Add iframes to removeVideos list

### DIFF
--- a/content.js
+++ b/content.js
@@ -42,7 +42,7 @@ function processPage(depth) {
 function removeVideos() {
 	/* Remove possible video tags from page to avoid sound playing. */
 	// Tags to remove
-	var VIDEO_TAGS = ['object', 'embed', 'video'];
+	var VIDEO_TAGS = ['object', 'embed', 'video', 'iframe'];
 
 	// Function for shorthand removal of nodes
 	function removeNode(node) {


### PR DESCRIPTION
Some sites will embed videos using an iframe rather than putting the video directly on the page. Since a content script lacks visibility into iframes, videos inside them will continue to play.